### PR TITLE
Fix widget path resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kirves/go-form-it
+
+go 1.13

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -32,11 +32,13 @@ func (w *Widget) Render(data interface{}) string {
 // BaseWidget creates a Widget based on style and inputType parameters, both defined in the common package.
 func BaseWidget(style, inputType string) *Widget {
 	var templatesPrefix = filepath.Join("templates", style)
-	var urls []string = []string{filepath.Join(templatesPrefix, "generic.tmpl")}
+	var urls []string = []string{"generic.tmpl"}
 
 	switch inputType {
-	case formcommon.BUTTON:
-		urls = append(urls, filepath.Join("button.html"))
+	case formcommon.BUTTON,
+		formcommon.RESET,
+		formcommon.SUBMIT:
+		urls = append(urls, "button.html")
 	case formcommon.CHECKBOX:
 		urls = append(urls, filepath.Join("options", "checkbox.html"))
 	case formcommon.TEXTAREA:
@@ -53,10 +55,6 @@ func BaseWidget(style, inputType string) *Widget {
 		urls = append(urls, filepath.Join("number", "range.html"))
 	case formcommon.NUMBER:
 		urls = append(urls, filepath.Join("number", "number.html"))
-	case formcommon.RESET:
-		urls = append(urls, filepath.Join("button.html"))
-	case formcommon.SUBMIT:
-		urls = append(urls, filepath.Join("button.html"))
 	case formcommon.DATE:
 		urls = append(urls, filepath.Join("datetime", "date.html"))
 	case formcommon.DATETIME:

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -79,11 +79,10 @@ func BaseWidget(style, inputType string) *Widget {
 	default:
 		urls = append(urls, filepath.Join(templatesPrefix, "input.html"))
 	}
-	styledUrls := make([]string, len(urls))
 	// resolve paths
 	for i := range urls {
 		urls[i] = formcommon.CreateUrl(filepath.Join(templatesPrefix, urls[i]))
 	}
-	templ := template.Must(template.ParseFiles(styledUrls...))
+	templ := template.Must(template.ParseFiles(urls...))
 	return &Widget{templ}
 }

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -5,9 +5,10 @@ package widgets
 
 import (
 	"bytes"
-	"fmt"
-	"github.com/kirves/go-form-it/common"
 	"html/template"
+	"path/filepath"
+
+	formcommon "github.com/kirves/go-form-it/common"
 )
 
 // Simple widget object that gets executed at render time.
@@ -28,42 +29,44 @@ func (w *Widget) Render(data interface{}) string {
 	return buf.String()
 }
 
-// BaseWidget creates a Widget based on style and inpuType parameters, both defined in the common package.
+// BaseWidget creates a Widget based on style and inputType parameters, both defined in the common package.
 func BaseWidget(style, inputType string) *Widget {
-	var urls []string = []string{formcommon.CreateUrl("templates/%s/generic.tmpl")}
+	var templatesPrefix = filepath.Join("templates", style)
+	var urls []string = []string{filepath.Join(templatesPrefix, "generic.tmpl")}
+
 	switch inputType {
 	case formcommon.BUTTON:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/button.html"))
+		urls = append(urls, filepath.Join("button.html"))
 	case formcommon.CHECKBOX:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/options/checkbox.html"))
+		urls = append(urls, filepath.Join("options", "checkbox.html"))
 	case formcommon.TEXTAREA:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/text/textareainput.html"))
+		urls = append(urls, filepath.Join("text", "textareainput.html"))
 	case formcommon.SELECT:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/options/select.html"))
+		urls = append(urls, filepath.Join("options", "select.html"))
 	case formcommon.PASSWORD:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/text/passwordinput.html"))
+		urls = append(urls, filepath.Join("text", "passwordinput.html"))
 	case formcommon.RADIO:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/options/radiobutton.html"))
+		urls = append(urls, filepath.Join("options", "radiobutton.html"))
 	case formcommon.TEXT:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/text/textinput.html"))
+		urls = append(urls, filepath.Join("text", "textinput.html"))
 	case formcommon.RANGE:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/number/range.html"))
+		urls = append(urls, filepath.Join("number", "range.html"))
 	case formcommon.NUMBER:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/number/number.html"))
+		urls = append(urls, filepath.Join("number", "number.html"))
 	case formcommon.RESET:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/button.html"))
+		urls = append(urls, filepath.Join("button.html"))
 	case formcommon.SUBMIT:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/button.html"))
+		urls = append(urls, filepath.Join("button.html"))
 	case formcommon.DATE:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/datetime/date.html"))
+		urls = append(urls, filepath.Join("datetime", "date.html"))
 	case formcommon.DATETIME:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/datetime/datetime.html"))
+		urls = append(urls, filepath.Join("datetime", "datetime.html"))
 	case formcommon.TIME:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/datetime/time.html"))
+		urls = append(urls, filepath.Join("datetime", "time.html"))
 	case formcommon.DATETIME_LOCAL:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/datetime/datetime.html"))
+		urls = append(urls, filepath.Join("datetime", "datetime.html"))
 	case formcommon.STATIC:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/static.html"))
+		urls = append(urls, filepath.Join("static.html"))
 	case formcommon.SEARCH,
 		formcommon.TEL,
 		formcommon.URL,
@@ -74,13 +77,14 @@ func BaseWidget(style, inputType string) *Widget {
 		formcommon.HIDDEN,
 		formcommon.IMAGE,
 		formcommon.MONTH:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/input.html"))
+		urls = append(urls, filepath.Join(templatesPrefix, "input.html"))
 	default:
-		urls = append(urls, formcommon.CreateUrl("templates/%s/input.html"))
+		urls = append(urls, filepath.Join(templatesPrefix, "input.html"))
 	}
 	styledUrls := make([]string, len(urls))
+	// resolve paths
 	for i := range urls {
-		styledUrls[i] = fmt.Sprintf(urls[i], style)
+		urls[i] = formcommon.CreateUrl(filepath.Join(templatesPrefix, urls[i]))
 	}
 	templ := template.Must(template.ParseFiles(styledUrls...))
 	return &Widget{templ}

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -75,9 +75,9 @@ func BaseWidget(style, inputType string) *Widget {
 		formcommon.HIDDEN,
 		formcommon.IMAGE,
 		formcommon.MONTH:
-		urls = append(urls, filepath.Join(templatesPrefix, "input.html"))
+		urls = append(urls, filepath.Join("input.html"))
 	default:
-		urls = append(urls, filepath.Join(templatesPrefix, "input.html"))
+		urls = append(urls, filepath.Join("input.html"))
 	}
 	// resolve paths
 	for i := range urls {


### PR DESCRIPTION
`formcommon.CreateUrl()` tried to os.Sta()t the path of `templates/%s/<something>` and of course it always failed.

* Now it forms the list of widgets, then resolves the path.
* use filepath.Join instead of literal "/"
* Added go.mod

![](https://media0.giphy.com/media/Qxu9xdcV59lCg/giphy.gif)